### PR TITLE
Modify ingress host to bypass a LetsEncrypt rate limit...

### DIFF
--- a/sock-shop/helm/templates/front-end.yaml
+++ b/sock-shop/helm/templates/front-end.yaml
@@ -38,11 +38,9 @@ metadata:
   labels:
     name: front-end
 spec:
-  type: NodePort
   ports:
   - port: 80
     targetPort: 8079
-    nodePort: 30001
   selector:
     name: front-end
 ---

--- a/sock-shop/helm/templates/front-end.yaml
+++ b/sock-shop/helm/templates/front-end.yaml
@@ -54,7 +54,7 @@ metadata:
   name: front-end
 spec:
   rules:
-  - host: sock-shop.devstg.aws.binbash.com.ar
+  - host: sockshop.devstg.aws.binbash.com.ar
     http:
       paths:
       - backend:
@@ -63,5 +63,5 @@ spec:
         path: /
   tls:
   - hosts:
-    - sock-shop.devstg.aws.binbash.com.ar
+    - sockshop.devstg.aws.binbash.com.ar
     secretName: front-end-tls


### PR DESCRIPTION
## what
* Change front-end service from NodePort to ClusterIP
* Modify ingress host to bypass a LetsEncrypt rate limit