### PR TITLE
Update Sock-Shop ingress host to work around a LetsEncrypt limit

### DIFF
--- a/sock-shop/helm/templates/front-end.yaml
+++ b/sock-shop/helm/templates/front-end.yaml
@@ -54,7 +54,7 @@ metadata:
   name: front-end
 spec:
   rules:
-  - host: sockshop.devstg.aws.binbash.com.ar
+  - host: sockshopapp.devstg.aws.binbash.com.ar
     http:
       paths:
       - backend:
@@ -63,5 +63,5 @@ spec:
         path: /
   tls:
   - hosts:
-    - sockshop.devstg.aws.binbash.com.ar
+    - sockshopapp.devstg.aws.binbash.com.ar
     secretName: front-end-tls


### PR DESCRIPTION
## what
* Update Sock-Shop ingress host to work around a LetsEncrypt limit