### PR TITLE
Sockshop DemoApp Refactors and Fixes

### DIFF
--- a/sock-shop/helm/templates/catalogue-db.yaml
+++ b/sock-shop/helm/templates/catalogue-db.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: catalogue-db
-        image: {{ index .Values "catalogue-db" "image" }}
+        image: {{ .Values.cataloguedb.image }}
         env:
           - name: MYSQL_ROOT_PASSWORD
             value: fake_password

--- a/sock-shop/helm/templates/catalogue-migrations.yaml
+++ b/sock-shop/helm/templates/catalogue-migrations.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.catalogueMigrations.enabled }}
+{{ if .Values.cataloguemigrations.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       annotations:
-{{ toYaml .Values.catalogueMigrations.annotations | indent 8 }}
+{{ toYaml .Values.cataloguemigrations.annotations | indent 8 }}
     spec:
       restartPolicy: Never
       containers:

--- a/sock-shop/helm/templates/catalogue.yaml
+++ b/sock-shop/helm/templates/catalogue.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
       - name: catalogue
         image: {{ .Values.catalogue.image }}
-{{ if .Values.catalogueMigrations.enabled }}
+{{ if .Values.cataloguemigrations.enabled }}
         command:
         - "/bin/sh"
         args:

--- a/sock-shop/helm/templates/front-end.yaml
+++ b/sock-shop/helm/templates/front-end.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: front-end
-        image: {{ index .Values "front-end" "image" }}
+        image: {{ .Values.frontend.image }}
         resources:
           requests:
             cpu: 100m
@@ -44,24 +44,34 @@ spec:
   selector:
     name: front-end
 ---
+{{- if .Values.frontend.ingress.enabled -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    cert-manager.io/cluster-issuer: clusterissuer-binbash-cert-manager-clusterissuer
-    kubernetes.io/ingress.class: ingress-nginx-private
-    kubernetes.io/tls-acme: "true"
+    {{- with .Values.frontend.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: front-end
 spec:
-  rules:
-  - host: sockshopapp.devstg.aws.binbash.com.ar
-    http:
-      paths:
-      - backend:
-          serviceName: front-end
-          servicePort: 80
-        path: /
+{{- if .Values.frontend.ingress.tls }}
   tls:
-  - hosts:
-    - sockshopapp.devstg.aws.binbash.com.ar
-    secretName: front-end-tls
+  {{- range .Values.frontend.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.frontend.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: front-end
+              servicePort: 80
+  {{- end }}
+{{- end }}

--- a/sock-shop/helm/templates/front-end.yaml
+++ b/sock-shop/helm/templates/front-end.yaml
@@ -45,7 +45,7 @@ spec:
     name: front-end
 ---
 {{- if .Values.frontend.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -70,8 +70,11 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: front-end
-              servicePort: 80
+              service:
+                name: front-end
+                port:
+                  number: 80
   {{- end }}
 {{- end }}

--- a/sock-shop/helm/templates/front-end.yaml
+++ b/sock-shop/helm/templates/front-end.yaml
@@ -44,7 +44,7 @@ spec:
   selector:
     name: front-end
 ---
-{{- if .Values.frontend.ingress.enabled -}}
+{{- if .Values.frontend.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/sock-shop/helm/templates/queue-master.yaml
+++ b/sock-shop/helm/templates/queue-master.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: queue-master
-        image: {{ index .Values "queue-master" "image" }}
+        image: {{ .Values.queuemaster.image }}
         ports:
         - containerPort: 80
       nodeSelector:

--- a/sock-shop/helm/templates/user-db.yaml
+++ b/sock-shop/helm/templates/user-db.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: user-db
-        image: {{ index .Values "user-db" "image" }}
+        image: {{ .Values.userdb.image }}
         ports:
         - name: mongo
           containerPort: 27017

--- a/sock-shop/helm/values-aws.yaml
+++ b/sock-shop/helm/values-aws.yaml
@@ -21,7 +21,7 @@ catalogue:
       {{- end }}
 
 # Run migrations -- we will use an external mysql service (RDS)
-catalogueMigrations:
+cataloguemigrations:
   enabled: true
   annotations: *catalogueAnnotations
 

--- a/sock-shop/helm/values.yaml
+++ b/sock-shop/helm/values.yaml
@@ -2,6 +2,7 @@ carts:
   image: weaveworksdemos/carts:0.4.8
 
 cataloguedb:
+  enabled: true
   image: weaveworksdemos/catalogue-db:0.3.0
 
 catalogue:
@@ -41,11 +42,7 @@ userdb:
 
 user:
   image: weaveworksdemos/user:0.4.7
-
-# Enable the in-cluster DB service that comes with this stack
-cataloguedb:
-  enabled: true
-
+  
 # Run migrations -- only needed when using an external mysql service
 cataloguemigrations:
   enabled: false

--- a/sock-shop/helm/values.yaml
+++ b/sock-shop/helm/values.yaml
@@ -1,15 +1,28 @@
 carts:
   image: weaveworksdemos/carts:0.4.8
 
-catalogue-db:
+cataloguedb:
   image: weaveworksdemos/catalogue-db:0.3.0
 
 catalogue:
   image: weaveworksdemos/catalogue:0.3.5  
   annotations: {}
 
-front-end:
+frontend:
   image: weaveworksdemos/front-end:0.3.12
+  ingress:
+    enabled: true
+    annotations:
+      cert-manager.io/cluster-issuer: clusterissuer-binbash-cert-manager-clusterissuer
+      kubernetes.io/ingress.class: ingress-nginx-private
+      kubernetes.io/tls-acme: "true"
+    paths: ['/']
+    hosts:
+      - sockshopapp.devstg.aws.binbash.com.ar
+    tls:
+      - secretName: front-end-tls
+        hosts:
+          - sockshopapp.devstg.aws.binbash.com.ar
 
 orders:
   image: weaveworksdemos/orders:0.4.7
@@ -17,13 +30,13 @@ orders:
 payment:
   image: weaveworksdemos/payment:0.4.3
 
-queue-master:
+queuemaster:
   image: weaveworksdemos/queue-master:0.3.1
 
 shipping:
   image: weaveworksdemos/shipping:0.4.8
 
-user-db:
+userdb:
   image: weaveworksdemos/user-db:0.4.0
 
 user:
@@ -34,5 +47,5 @@ cataloguedb:
   enabled: true
 
 # Run migrations -- only needed when using an external mysql service
-catalogueMigrations:
+cataloguemigrations:
   enabled: false


### PR DESCRIPTION
## what
* Refactor SockShop chart to allow multiple ingress hostnames
* Migrate front-end ingress to new spec
* Fix an issue with a trim directive making the ingress declaration break in ArgoCD

## why
* We were facing an issue when deploying SockShop DemoApp through ArgoCD.
* ArgoCD was failing to validate the app with an 'Ingress "" not found' error message which was hard to understand.
