### PR TITLE
Fix | updating k8s ingress apiVersion to networking.k8s.io/v1

### DIFF
--- a/eks-py-az/helm/templates/ingress.yaml
+++ b/eks-py-az/helm/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: "py-az-ingress"

--- a/emojivoto/kubernetes/web.yml
+++ b/emojivoto/kubernetes/web.yml
@@ -59,7 +59,7 @@ spec:
     app: web-svc
   type: ClusterIP
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:

--- a/google-microservices-demo/kubernetes/frontend.yaml
+++ b/google-microservices-demo/kubernetes/frontend.yaml
@@ -108,7 +108,7 @@ spec:
 #     port: 80
 #     targetPort: 8080
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:

--- a/sock-shop/kubernetes/front-end.yaml
+++ b/sock-shop/kubernetes/front-end.yaml
@@ -46,7 +46,7 @@ spec:
   selector:
     name: front-end
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:


### PR DESCRIPTION
## What?

### Commits on Jul 14, 2022
- [updating k8s ingress apiVersion to networking.k8s.io/v1](https://github.com/binbashar/le-demo-apps/commit/efaf66f3b8ccd8af42d3a005f41da7cb9420bd8d) - @[exequielrafaela](https://github.com/binbashar/le-demo-apps/commits?author=exequielrafaela)

## Why? 
- Deploy emoji-voto app at the new K8s EKS 1.22 cluster => https://github.com/binbashar/le-tf-infra-aws/tree/master/apps-devstg/us-east-1/k8s-eks