### PR TITLE
Fix | k8s ingress object fields updated for new api version

### DIFF
--- a/eks-py-az/helm/templates/ingress.yaml
+++ b/eks-py-az/helm/templates/ingress.yaml
@@ -27,7 +27,7 @@ spec:
         paths:
           - path: /
             backend:
-              serviceName: py-az
-              servicePort: 80
+              service.name: py-az
+              service.port.number: 80
   {{- end }}
 {{- end }}

--- a/emojivoto/kubernetes/web.yml
+++ b/emojivoto/kubernetes/web.yml
@@ -77,8 +77,8 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: web-svc
-          servicePort: 80
+          service.name: web-svc
+          service.port.number: 80
         path: /
   tls:
   - hosts:

--- a/google-microservices-demo/kubernetes/frontend.yaml
+++ b/google-microservices-demo/kubernetes/frontend.yaml
@@ -122,8 +122,8 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: frontend
-          servicePort: 80
+          service.name: frontend
+          service.port.number: 80
         path: /
   tls:
   - hosts:

--- a/sock-shop/kubernetes/front-end.yaml
+++ b/sock-shop/kubernetes/front-end.yaml
@@ -60,8 +60,8 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: front-end
-          servicePort: 80
+          service.name: front-end
+          service.port.number: 80
         path: /
   tls:
   - hosts:


### PR DESCRIPTION
## What?

### Commits on Jul 14, 2022
- [updating k8s ingress object fields to meet networking.k8s.io/v1 specification](https://github.com/binbashar/le-demo-apps/commit/1cd33ac3668e2ddf18c8ed229cfe92b8edb6c63f)  - @[exequielrafaela](https://github.com/binbashar/le-demo-apps/commits?author=exequielrafaela)
- [Merge branch 'master' into feature/k8s-ingress-api-version-update](https://github.com/binbashar/le-demo-apps/commit/caa2fc3a6328e224a4c31d9666606e0990b1b576) - @[exequielrafaela](https://github.com/binbashar/le-demo-apps/commits?author=exequielrafaela)

## Why? 
- Deploy emoji-voto app at the new K8s EKS 1.22 cluster => https://github.com/binbashar/le-tf-infra-aws/tree/master/apps-devstg/us-east-1/k8s-eks
