### PR TITLE
Fix | k8s ingress object fields to meet networking.k8s.io/v1 specification

### DIFF
--- a/eks-py-az/helm/templates/ingress.yaml
+++ b/eks-py-az/helm/templates/ingress.yaml
@@ -27,7 +27,9 @@ spec:
         paths:
           - path: /
             backend:
-              service.name: py-az
-              service.port.number: 80
+              service:
+                name: py-az
+                port:
+                  number: 80
   {{- end }}
 {{- end }}

--- a/emojivoto/kubernetes/web.yml
+++ b/emojivoto/kubernetes/web.yml
@@ -77,8 +77,10 @@ spec:
     http:
       paths:
       - backend:
-          service.name: web-svc
-          service.port.number: 80
+          service:
+            name: web-svc
+            port:
+              number: 80
         path: /
   tls:
   - hosts:

--- a/google-microservices-demo/kubernetes/frontend.yaml
+++ b/google-microservices-demo/kubernetes/frontend.yaml
@@ -122,8 +122,10 @@ spec:
     http:
       paths:
       - backend:
-          service.name: frontend
-          service.port.number: 80
+          service:
+            name: frontend
+            port:
+              number: 80
         path: /
   tls:
   - hosts:

--- a/sock-shop/kubernetes/front-end.yaml
+++ b/sock-shop/kubernetes/front-end.yaml
@@ -60,8 +60,10 @@ spec:
     http:
       paths:
       - backend:
-          service.name: front-end
-          service.port.number: 80
+          service:
+            name: front-end
+            port:
+              number: 80
         path: /
   tls:
   - hosts:


### PR DESCRIPTION
## What?

### Commits on Jul 14, 2022
- [fix k8s ingress object fields to meet networking.k8s.io/v1 specification](https://github.com/binbashar/le-demo-apps/commit/665fe1c00694e2050f252de8453e1a7813b9a5df) - @[exequielrafaela](https://github.com/binbashar/le-demo-apps/commits?author=exequielrafaela)

## Why? 
- Deploy emoji-voto app at the new K8s EKS 1.22 cluster => https://github.com/binbashar/le-tf-infra-aws/tree/master/apps-devstg/us-east-1/k8s-eks