### PR TITLE
Fix | update to new kubernetes.io/ingress.class: private-apps

### DIFF
--- a/eks-py-az/helm/values-primary.yaml
+++ b/eks-py-az/helm/values-primary.yaml
@@ -2,7 +2,7 @@ ingress:
   enabled: true
   annotations:
     cert-manager.io/cluster-issuer: clusterissuer-binbash-cert-manager-clusterissuer
-    kubernetes.io/ingress.class: ingress-nginx-private
+    kubernetes.io/ingress.class: private-apps
     kubernetes.io/tls-acme: "true"
   paths: ['/']
   hosts:

--- a/eks-py-az/helm/values-secondary.yaml
+++ b/eks-py-az/helm/values-secondary.yaml
@@ -2,7 +2,7 @@ ingress:
   enabled: true
   annotations:
     cert-manager.io/cluster-issuer: clusterissuer-binbash-cert-manager-clusterissuer
-    kubernetes.io/ingress.class: ingress-nginx-private
+    kubernetes.io/ingress.class: private-apps
     kubernetes.io/tls-acme: "true"
   paths: ['/']
   hosts:

--- a/emojivoto/kubernetes/web.yml
+++ b/emojivoto/kubernetes/web.yml
@@ -64,7 +64,7 @@ kind: Ingress
 metadata:
   annotations:
     cert-manager.io/cluster-issuer: clusterissuer-binbash-cert-manager-clusterissuer
-    kubernetes.io/ingress.class: ingress-nginx-private
+    kubernetes.io/ingress.class: private-apps
     kubernetes.io/tls-acme: "true"
   labels:
     app.kubernetes.io/name: web

--- a/google-microservices-demo/kubernetes/frontend.yaml
+++ b/google-microservices-demo/kubernetes/frontend.yaml
@@ -113,7 +113,7 @@ kind: Ingress
 metadata:
   annotations:
     cert-manager.io/cluster-issuer: clusterissuer-binbash-cert-manager-clusterissuer
-    kubernetes.io/ingress.class: ingress-nginx-private
+    kubernetes.io/ingress.class: private-apps
     kubernetes.io/tls-acme: "true"
   name: frontend
 spec:

--- a/sock-shop/helm/values.yaml
+++ b/sock-shop/helm/values.yaml
@@ -6,7 +6,7 @@ cataloguedb:
   image: weaveworksdemos/catalogue-db:0.3.0
 
 catalogue:
-  image: weaveworksdemos/catalogue:0.3.5  
+  image: weaveworksdemos/catalogue:0.3.5
   annotations: {}
 
 frontend:
@@ -15,7 +15,7 @@ frontend:
     enabled: true
     annotations:
       cert-manager.io/cluster-issuer: clusterissuer-binbash-cert-manager-clusterissuer
-      kubernetes.io/ingress.class: ingress-nginx-private
+      kubernetes.io/ingress.class: private-apps
       kubernetes.io/tls-acme: "true"
     paths: ['/']
     hosts:
@@ -42,7 +42,7 @@ userdb:
 
 user:
   image: weaveworksdemos/user:0.4.7
-  
+
 # Run migrations -- only needed when using an external mysql service
 cataloguemigrations:
   enabled: false

--- a/sock-shop/kubernetes/front-end.yaml
+++ b/sock-shop/kubernetes/front-end.yaml
@@ -51,7 +51,7 @@ kind: Ingress
 metadata:
   annotations:
     cert-manager.io/cluster-issuer: clusterissuer-binbash-cert-manager-clusterissuer
-    kubernetes.io/ingress.class: ingress-nginx-private
+    kubernetes.io/ingress.class: private-apps
     kubernetes.io/tls-acme: "true"
   name: front-end
 spec:


### PR DESCRIPTION
## What?

### Commits on Jul 14, 2022
- [Updating kubernetes.io/ingress-class to meet our ref arch new definition](https://github.com/binbashar/le-demo-apps/commit/8db1b47156fef34beff1d85aaa9ddd3fe6020fdb) - @[exequielrafaela](https://github.com/binbashar/le-demo-apps/commits?author=exequielrafaela)

- [Merge branch 'fix/k8s-ingress-object-api-v1' of github.com:binbashar/le-demo-apps into fix/k8s-ingress-object-api-v1](https://github.com/binbashar/le-demo-apps/commit/4ecfeb8f13302885f19481ede6bb2c113fd56508)  - @[exequielrafaela](https://github.com/binbashar/le-demo-apps/commits?author=exequielrafaela)

```
- kubernetes.io/ingress.class: ingress-nginx-private
+ kubernetes.io/ingress.class: private-apps
```

## Why? 
- Deploy emoji-voto app at the new K8s EKS 1.22 cluster => https://github.com/binbashar/le-tf-infra-aws/tree/master/apps-devstg/us-east-1/k8s-eks


